### PR TITLE
Feature/add gpt version to config

### DIFF
--- a/goc/config.py
+++ b/goc/config.py
@@ -66,7 +66,7 @@ def read_config() -> Dict[str,str]:
 
 
 def parse_config() -> Dict[str,str]:
-    default_config = get_default_template_dict
+    default_config = get_default_template_dict()
     if os.path.exists(CONFIG_PATH):
         config = read_config()
         # check if any fields are missing

--- a/goc/config.py
+++ b/goc/config.py
@@ -71,7 +71,7 @@ def parse_config() -> Dict[str,str]:
         config = read_config()
         # check if any fields are missing
         if config.keys() != default_config.keys():
-            upd_config = default_config | config
+            upd_config = {**default_config, **config}
             write_config(upd_config)
             config = upd_config
     else:

--- a/goc/goc.py
+++ b/goc/goc.py
@@ -4,7 +4,7 @@ from typing import List
 import click
 import openai
 
-from goc.config import get_template, TemplateType
+from goc.config import get_template, TemplateType, get_gpt_ver
 
 
 def exec_bash_cmd(cmd):
@@ -47,7 +47,9 @@ def git_commit_wrap(m: str = None):
     return prompt_chain
 
 
-def execute_prompt_chain(prompt_chain, gpt_ver='3.5-turbo'):
+def execute_prompt_chain(prompt_chain, gpt_ver=None):
+    if gpt_ver is None:
+        gpt_ver = get_gpt_ver()
     resp = openai.ChatCompletion.create(
         model=f"gpt-{gpt_ver}",
         messages=[
@@ -82,7 +84,7 @@ def commit_cmd():
 
 
 @diff_cmd.command(help="Generate documentation for the git diff between commits or files")
-@click.option("--gpt_ver", help="GPT model version to use", default="3.5-turbo")
+@click.option("--gpt_ver", help="GPT model version to use", default=None)
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
 def diff(gpt_ver: str, args: List[str]):
     prompt_chain = []
@@ -94,7 +96,7 @@ def diff(gpt_ver: str, args: List[str]):
 
 
 @commit_cmd.command(help="Generate a commit message for the current git diff")
-@click.option("--gpt_ver", help="GPT model version to use", default="3.5-turbo")
+@click.option("--gpt_ver", help="GPT model version to use", default=None)
 @click.option("-m", help="Hint Message to send to chat GPT", default=None)
 def commit(gpt_ver: str, m: str):
     prompt_chain = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "goc"
-version = "0.6.1"
+version = "0.6.2"
 description = ""
 authors = ["Todd Perry <toddperry171@gmail.com>", "Masa Fukui <masahiro.m.fukui@gmail.com"]
 readme = "README.md"


### PR DESCRIPTION
# Git Commit Diff

## Description
- Update the version in pyproject.toml

## Files Modified
- `goc/config.py`: Add a default GPT version constant and update the generate_default_template function to include the GPT version in the config file.
- `goc/goc.py`: Add a new function get_gpt_ver to read the GPT version from the config file and modify the execute_prompt_chain function to use the GPT version from the config file instead of the command line argument.
- `pyproject.toml`: Update the version to 0.6.2.

## Changes Made
- In `goc/config.py`:
  - Added a new constant `DEFAULT_GPT_VER` with a value of "3.5-turbo".
  - Modified the `generate_default_template` function to include the `DEFAULT_GPT_VER` in the default template dictionary.
  - Added a new function `write_config` to write the config dictionary to the config file.
  - Modified the `parse_config` function to check if any fields are missing in the config file and update it with the default values if necessary.
  - Added a new function `get_gpt_ver` to read the GPT version from the config file.
- In `goc/goc.py`:
  - Imported the new `get_gpt_ver` function from `goc/config`.
  - Modified the `execute_prompt_chain` function to use the GPT version from the config file instead of the command line argument.
  - Modified the `diff` and `commit` functions to remove the default value for the `gpt_ver` argument.
- In `pyproject.toml`:
  - Updated the version to 0.6.2.